### PR TITLE
use stable kotlin coroutines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 
 buildscript {
 
-    ext.kotlin_version = '1.2.50'
-    ext.coroutines_version = '0.25.3'
+    ext.kotlin_version = '1.3.21'
+    ext.coroutines_version = '1.1.1'
     ext.rxjava = '2.2.2'
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.4.0-rc02'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.4.0-rc02'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 06 10:39:05 CEST 2018
+#Sat Mar 16 19:41:38 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 16 19:41:38 CET 2019
+#Thu Sep 06 10:39:05 CEST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/inline-activity-result-kotlin/build.gradle
+++ b/inline-activity-result-kotlin/build.gradle
@@ -24,12 +24,6 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
 }
 
-kotlin {
-    experimental {
-        coroutines "enable"
-    }
-}
-
 ext {
     bintrayRepo = 'maven'
     bintrayName = rootProject.ext.libraryName+'-kotlin'

--- a/inline-activity-result-kotlin/src/main/java/com/github/florent37/inlineactivityresult/kotlin/coroutines/kotlin-activity-result-coroutines.kt
+++ b/inline-activity-result-kotlin/src/main/java/com/github/florent37/inlineactivityresult/kotlin/coroutines/kotlin-activity-result-coroutines.kt
@@ -1,4 +1,4 @@
-package com.github.florent37.inlineactivityresult.kotlin.coroutines.experimental
+package com.github.florent37.inlineactivityresult.kotlin.coroutines
 
 import android.content.Intent
 import android.support.v4.app.Fragment
@@ -7,7 +7,9 @@ import com.github.florent37.inlineactivityresult.InlineActivityResult
 import com.github.florent37.inlineactivityresult.Result
 import com.github.florent37.inlineactivityresult.kotlin.InlineActivityException
 import com.github.florent37.inlineactivityresult.kotlin.InlineActivityResultException
-import kotlin.coroutines.experimental.suspendCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 
 suspend fun FragmentActivity.startForResult(intent: Intent): Result = suspendCoroutine { continuation ->
     var resumed = false

--- a/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/InlineActivityResult.java
+++ b/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/InlineActivityResult.java
@@ -1,0 +1,143 @@
+package com.github.florent37.inlineactivityresult;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+
+import com.github.florent37.inlineactivityresult.callbacks.ActivityResultListener;
+import com.github.florent37.inlineactivityresult.callbacks.FailCallback;
+import com.github.florent37.inlineactivityresult.callbacks.SuccessCallback;
+
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+public class InlineActivityResult {
+
+    private static final String TAG = "ACTIVITY_RESULT_FRAGMENT_WEEEEE";
+
+    private final Reference<FragmentActivity> activityReference;
+
+    //region callbacks
+    private final List<ActivityResultListener> responseListeners = new ArrayList<>();
+    private final List<SuccessCallback> successCallbacks = new ArrayList<>();
+    private final List<FailCallback> failCallbacks = new ArrayList<>();
+
+    //the listener we will give to the fragment
+    private final ActivityResultFragment.ActivityResultListener listener = new ActivityResultFragment.ActivityResultListener() {
+        @Override
+        public void onActivityResult(int requestCode, int resultCode, Intent data) {
+            onReceivedActivityResult(requestCode, resultCode, data);
+        }
+    };
+    //endregion
+
+    public static InlineActivityResult startForResult(final FragmentActivity activity, @Nullable final Intent intent, @Nullable final ActivityResultListener listener){
+        return new InlineActivityResult(activity).startForResult(intent, listener);
+    }
+
+    public static InlineActivityResult startForResult(final Fragment fragment, @Nullable final Intent intent, @Nullable final ActivityResultListener listener){
+        return new InlineActivityResult(fragment).startForResult(intent, listener);
+    }
+
+    public InlineActivityResult(@Nullable final FragmentActivity activity) {
+        if (activity != null) {
+            this.activityReference = new WeakReference<>(activity);
+        } else {
+            this.activityReference = new WeakReference<>(null);
+        }
+    }
+
+    public InlineActivityResult(@Nullable final Fragment fragment) {
+        FragmentActivity activity = null;
+        if (fragment != null) {
+            activity = fragment.getActivity();
+        }
+        if (activity != null) {
+            this.activityReference = new WeakReference<>(activity);
+        } else {
+            this.activityReference = new WeakReference<>(null);
+        }
+    }
+
+    private void onReceivedActivityResult(int requestCode, int resultCode, @Nullable final Intent data) {
+        final Result result = new Result(this, requestCode, resultCode, data);
+        if (resultCode == Activity.RESULT_OK) {
+            for (SuccessCallback callback : successCallbacks) {
+                callback.onSuccess(result);
+            }
+            for (ActivityResultListener listener : responseListeners) {
+                listener.onSuccess(result);
+            }
+        } else if (resultCode == Activity.RESULT_CANCELED) {
+            for (FailCallback callback : failCallbacks) {
+                callback.onFailed(result);
+            }
+            for (ActivityResultListener listener : responseListeners) {
+                listener.onFailed(result);
+            }
+        }
+    }
+
+    public InlineActivityResult startForResult(@Nullable final Intent intent) {
+        if (intent != null) {
+            this.start(intent);
+        }
+        return this;
+    }
+
+    public InlineActivityResult startForResult(@Nullable final Intent intent, @Nullable final ActivityResultListener listener) {
+        if (intent != null && listener != null) {
+            this.responseListeners.add(listener);
+            this.start(intent);
+        }
+        return this;
+    }
+
+    public InlineActivityResult onSuccess(@Nullable final SuccessCallback callback) {
+        if (callback != null) {
+            successCallbacks.add(callback);
+        }
+        return this;
+    }
+
+    public InlineActivityResult onFail(@Nullable final FailCallback callback) {
+        if (callback != null) {
+            failCallbacks.add(callback);
+        }
+        return this;
+    }
+
+    private void start(@NonNull final Intent intent) {
+        final FragmentActivity activity = activityReference.get();
+        if (activity == null || activity.isFinishing()) {
+            return;
+        }
+
+        final ActivityResultFragment oldFragment = (ActivityResultFragment) activity
+                .getSupportFragmentManager()
+                .findFragmentByTag(TAG);
+
+        if (oldFragment != null) {
+            oldFragment.setListener(listener);
+        } else {
+            final ActivityResultFragment newFragment = ActivityResultFragment.newInstance(intent);
+            newFragment.setListener(listener);
+
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    activity.getSupportFragmentManager()
+                            .beginTransaction()
+                            .add(newFragment, TAG)
+                            .commitNowAllowingStateLoss();
+                }
+            });
+
+        }
+    }
+}

--- a/sample/src/main/java/com/github/florent37/inlineactivityresult/sample/MainActivityKotlinCoroutine.kt
+++ b/sample/src/main/java/com/github/florent37/inlineactivityresult/sample/MainActivityKotlinCoroutine.kt
@@ -6,10 +6,11 @@ import android.os.Bundle
 import android.provider.MediaStore
 import android.support.v7.app.AppCompatActivity
 import com.github.florent37.inlineactivityresult.kotlin.InlineActivityResultException
-import com.github.florent37.inlineactivityresult.kotlin.coroutines.experimental.startForResult
+import com.github.florent37.inlineactivityresult.kotlin.coroutines.startForResult
 import kotlinx.android.synthetic.main.activity_request.*
-import kotlinx.coroutines.experimental.android.UI
-import kotlinx.coroutines.experimental.launch
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 class MainActivityKotlinCoroutine : AppCompatActivity() {
 
@@ -22,7 +23,7 @@ class MainActivityKotlinCoroutine : AppCompatActivity() {
         }
     }
 
-    fun myMethod() = launch(UI) {
+    fun myMethod() = GlobalScope.launch(Dispatchers.Main) {
         try {
             val result = startForResult(Intent(MediaStore.ACTION_IMAGE_CAPTURE))
 


### PR DESCRIPTION
Hi 👋 

This PR goal is to upgrade the kotlin coroutine version used in this library to use the final version instead of the experimental one.

### Updated
- Upgrade kotlin to last state version
- Use last stable kotlin coroutines version
- Rename package `com.github.florent37.inlineactivityresult.kotlin.coroutines.experimental` -> `com.github.florent37.inlineactivityresult.kotlin.coroutines`
 