### PR TITLE
Fix infinite start for result

### DIFF
--- a/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/ActivityResultFragment.java
+++ b/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/ActivityResultFragment.java
@@ -52,9 +52,7 @@ public class ActivityResultFragment extends Fragment {
             startActivityForResult(intentToStart, REQUEST_CODE);
         } else {
             // this shouldn't happen, but just to be sure
-            getFragmentManager().beginTransaction()
-                    .remove(this)
-                    .commitAllowingStateLoss();
+            removeFragment();
         }
     }
 
@@ -65,11 +63,8 @@ public class ActivityResultFragment extends Fragment {
         if (requestCode == REQUEST_CODE) {
             if (listener != null) {
                 listener.onActivityResult(requestCode, resultCode, data);
-
-                getFragmentManager().beginTransaction()
-                        .remove(this)
-                        .commitAllowingStateLoss();
             }
+            removeFragment();
         }
     }
 
@@ -78,6 +73,12 @@ public class ActivityResultFragment extends Fragment {
             this.listener = listener;
         }
         return this;
+    }
+
+    private void removeFragment() {
+        getFragmentManager().beginTransaction()
+                .remove(this)
+                .commitAllowingStateLoss();
     }
 
     interface ActivityResultListener {


### PR DESCRIPTION
Fix issue #5 

When the activity/fragment that calls the `startForResult` gets destroyed and the called Intent finish:

1- The `ActivityResultFragment#onActivityResult` gets called but the `listener` is null (because the fragment has been recreated), which results in the fragment not being removed from the fragment manager.

2- The `onResume` is called and the started intent is called again.


**Solution**: Avoid calling the startActivityForResult if it has already been called by removing the Fragment when onActivityResult is called even if the `listener` is null.

**Drawbacks**: When the calling activity is destroyed after calling `startForResult`, the Intent result cannot be propagated to it. I couldn't find a proper solution to get it works in this case.