### PR TITLE
Fixed startActivityForResult calling multiple times issue

### DIFF
--- a/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/ActivityResultFragment.java
+++ b/inline-activity-result/src/main/java/com/github/florent37/inlineactivityresult/ActivityResultFragment.java
@@ -53,9 +53,10 @@ public class ActivityResultFragment extends Fragment {
     }
 
     @Override
-    public void onResume() {
-        super.onResume();
+    public void onActivityCreated(@Nullable Bundle savedInstanceState) {
+        super.onActivityCreated(savedInstanceState);
 
+        //Execute Request
         executeRequest();
     }
 


### PR DESCRIPTION
Reproduction Steps:
- Launch Activity A using the startForResult extensions method.
- Launch another Activity B using startActivityForResult.
- Observe when Activity B result returns it start the Activity A again.

I'm using this library into [ImagePicker](https://github.com/Dhaval2404/ImagePicker) and many people are facing this issue when InlineActivityResult is used for Activity Results.

Let me know if you need anything else to reproduce the issue. 